### PR TITLE
Add NullHandler to logging instance

### DIFF
--- a/twitch/logging.py
+++ b/twitch/logging.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 import logging
 
 log = logging.getLogger('twitch')
+log.addHandler(logging.NullHandler())
 
 
 def deprecation_warning(logger, old, new):


### PR DESCRIPTION
When no logging is configured, the absence of a logging handler makes
python output a warning to stdout. Adding a NullHandler resolves this
issue.

Closes #15